### PR TITLE
Refactor DTOs for order management

### DIFF
--- a/Capstone/Capstone.SRHP.ServiceLayer/DTOs/Management/OrderManagementModels.cs
+++ b/Capstone/Capstone.SRHP.ServiceLayer/DTOs/Management/OrderManagementModels.cs
@@ -23,7 +23,7 @@ namespace Capstone.HPTY.ServiceLayer.DTOs.Management
     {
         public bool IsDelivered { get; set; }
 
-        public string Notes { get; set; }
+        public string? Notes { get; set; }
     }
 
     public class UpdateDeliveryTimeRequest
@@ -142,14 +142,16 @@ namespace Capstone.HPTY.ServiceLayer.DTOs.Management
     }
     public class OrderStatusUpdateDTO
     {
-        public string OrderId { get; set; }
+        public string OrderCode { get; set; }
+        public int OrderId { get; set; }
         public OrderStatus Status { get; set; }
         public DateTime UpdatedAt { get; set; }
     }
 
     public class OrderDetailDTO
     {
-        public string OrderId { get; set; }
+        public string OrderCode { get; set; }
+        public int OrderId { get; set; }
         public string Address { get; set; }
         public string Notes { get; set; }
         public decimal TotalPrice { get; set; }
@@ -180,7 +182,9 @@ namespace Capstone.HPTY.ServiceLayer.DTOs.Management
     public class DeliveryStatusUpdateDTO
     {
         public int ShippingOrderId { get; set; }
-        public string OrderId { get; set; }
+        public string OrderCode { get; set; }
+        public int OrderId { get; set; }
+
         public bool IsDelivered { get; set; }
         public DateTime? DeliveryTime { get; set; }
         public string DeliveryNotes { get; set; }

--- a/Capstone/Capstone.SRHP.ServiceLayer/Services/ManagerService/OrderManagementService.cs
+++ b/Capstone/Capstone.SRHP.ServiceLayer/Services/ManagerService/OrderManagementService.cs
@@ -207,7 +207,8 @@ namespace Capstone.HPTY.ServiceLayer.Services.ManagerService
                 // Map to DTO
                 return new OrderStatusUpdateDTO
                 {
-                    OrderId = order.OrderCode,
+                    OrderCode = order.OrderCode,
+                    OrderId = order.OrderId,
                     Status = order.Status,
                     UpdatedAt = order.UpdatedAt ?? DateTime.UtcNow
                 };
@@ -250,7 +251,8 @@ namespace Capstone.HPTY.ServiceLayer.Services.ManagerService
                 // Map to DTO
                 var orderDetailDTO = new OrderDetailDTO
                 {
-                    OrderId = order.OrderCode,
+                    OrderCode = order.OrderCode,
+                    OrderId = order.OrderId,
                     Address = order.Address,
                     Notes = order.Notes ?? string.Empty,
                     TotalPrice = order.TotalPrice,
@@ -325,7 +327,8 @@ namespace Capstone.HPTY.ServiceLayer.Services.ManagerService
                 return new DeliveryStatusUpdateDTO
                 {
                     ShippingOrderId = shippingOrder.ShippingOrderId,
-                    OrderId = shippingOrder.Order.OrderCode,
+                    OrderCode = shippingOrder.Order.OrderCode,
+                    OrderId = shippingOrder.OrderId,
                     IsDelivered = shippingOrder.IsDelivered,
                     DeliveryTime = shippingOrder.DeliveryTime,
                     DeliveryNotes = shippingOrder.DeliveryNotes ?? string.Empty,


### PR DESCRIPTION
- Made `Notes` property nullable in `UpdateDeliveryStatusRequest`.
- Updated `OrderStatusUpdateDTO` and `OrderDetailDTO` to replace `OrderId` with `OrderCode` (string) and added a new `OrderId` (int).
- Modified `DeliveryStatusUpdateDTO` to replace `OrderId` with `OrderCode` and added `OrderId` (int) and `IsDelivered` properties.
- Updated mappings in `OrderManagementService.cs` to reflect the new property names and types.