### PR TITLE
Add OrderCode to PaymentReceiptDto and refactor receipt logic

### DIFF
--- a/Capstone/Capstone.SRHP.ServiceLayer/DTOs/Payments/StaffPaymentModels.cs
+++ b/Capstone/Capstone.SRHP.ServiceLayer/DTOs/Payments/StaffPaymentModels.cs
@@ -25,6 +25,7 @@ namespace Capstone.HPTY.ServiceLayer.DTOs.Payments
     {
         public int ReceiptId { get; init; }
         public int OrderId { get; init; }
+        public string OrderCode { get; init; } = string.Empty;
         public int PaymentId { get; init; }
         public string TransactionCode { get; init; } = string.Empty;
         public decimal Amount { get; init; }
@@ -40,7 +41,7 @@ namespace Capstone.HPTY.ServiceLayer.DTOs.Payments
         public DateTime? FromDate { get; init; }
         public DateTime? ToDate { get; init; }
         public string? SortBy { get; init; } = "CreatedAt";
-        public bool SortDescending { get; init; } = true;     
+        public bool SortDescending { get; init; } = true;
     }
 
     public record PaymentListItemDto


### PR DESCRIPTION
- Updated `PaymentReceiptDto` to include `OrderCode` for better tracking of payment receipts.
- Minor no-op change to `SortDescending` in `PaymentListItemDto`.
- Refactored receipt handling in `StaffPaymentService` to first check for existing receipts, improving efficiency and avoiding duplicates.
- Enhanced robustness of returned `PaymentReceiptDto` by defaulting `OrderCode`, `TransactionCode`, and `PaymentMethod` to "Unknown" if not available.