### PR TITLE
Add vehicle information mapping to StaffOrderService

### DIFF
--- a/Capstone/Capstone.SRHP.ServiceLayer/Services/StaffService/StaffOrderService.cs
+++ b/Capstone/Capstone.SRHP.ServiceLayer/Services/StaffService/StaffOrderService.cs
@@ -657,6 +657,9 @@ namespace Capstone.HPTY.ServiceLayer.Services.StaffService
                 UpdatedAt = order.UpdatedAt,
                 DeliveryTime = order.DeliveryTime,
 
+                // Add vehicle information
+                Vehicle = MapToVehicleInfoDto(order.ShippingOrder?.Vehicle),
+
                 // Order details
                 OrderDetails = order.SellOrder?.SellOrderDetails?.Select(MapToOrderDetailDto).ToList() ?? new List<OrderDetailDto>(),
                 RentalDetails = order.RentOrder?.RentOrderDetails?.Select(MapToRentalDetailDto).ToList() ?? new List<RentalDetailDto>(),
@@ -903,6 +906,18 @@ namespace Capstone.HPTY.ServiceLayer.Services.StaffService
             }
 
             return dto;
+        }
+
+        private VehicleInfoDto MapToVehicleInfoDto(Vehicle vehicle)
+        {
+            if (vehicle == null) return null;
+
+            return new VehicleInfoDto
+            {
+                VehicleId = vehicle.VehicleId,
+                VehicleName = vehicle.Name,
+                LicensePlate = vehicle.LicensePlate,
+            };
         }
     }
 }


### PR DESCRIPTION
This update introduces a new `Vehicle` property in the `StaffOrderService` class to map vehicle information from the associated `ShippingOrder`. A private method `MapToVehicleInfoDto` is also added to convert a `Vehicle` object into a `VehicleInfoDto`, handling null cases appropriately.