### PR TITLE
Adjust CompletedDate to 7 hours ahead in assignments

### DIFF
--- a/Capstone/Capstone.SRHP.ServiceLayer/Services/StaffService/StaffOrderService.cs
+++ b/Capstone/Capstone.SRHP.ServiceLayer/Services/StaffService/StaffOrderService.cs
@@ -277,7 +277,7 @@ namespace Capstone.HPTY.ServiceLayer.Services.StaffService
                         // Mark all preparation assignments as completed
                         foreach (var assignment in allPreparationAssignments)
                         {
-                            assignment.CompletedDate = DateTime.UtcNow;
+                            assignment.CompletedDate = DateTime.UtcNow.AddHours(7);
                             assignment.SetUpdateDate();
                             _logger.LogInformation("Marked preparation assignment {AssignmentId} for staff {StaffId} as completed",
                                 assignment.StaffAssignmentId, assignment.StaffId);


### PR DESCRIPTION
This change modifies the `CompletedDate` property of `assignment` in the `StaffOrderService.cs` file. The completion time is now set to 7 hours ahead of the current UTC time instead of the actual UTC time, which alters how completion timestamps are recorded for preparation assignments.